### PR TITLE
Added editorial for LOJ-1166: Old Sort

### DIFF
--- a/1166/correct_position.svg
+++ b/1166/correct_position.svg
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="544"
+   height="480"
+   viewBox="0 0 143.93333 127"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="correct_position.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="242.2912"
+     inkscape:cy="339.64739"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer3"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1431"
+     inkscape:window-height="1030"
+     inkscape:window-x="96"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2"
+     style="display:inline">
+    <rect
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.654579"
+       id="rect1611"
+       width="144.59282"
+       height="134.16931"
+       x="0"
+       y="-4.543582" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.558772"
+       id="rect1402"
+       width="106.46908"
+       height="25.48641"
+       x="32.29171"
+       y="35.498943" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.230261px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 63.600115,36.094105 c 0,25.328596 0.555363,25.133761 0.555363,25.133761"
+       id="path1412" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.229579px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 102.89877,61.778868 C 102.6315,34.2105 102.36423,34.2105 102.36423,34.2105"
+       id="path1414" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="116.79678"
+       y="51.850288"
+       id="text1418"><tspan
+         sodipodi:role="line"
+         id="tspan1416"
+         x="116.79678"
+         y="51.850288"
+         style="stroke-width:0.264583">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="44.634014"
+       y="51.850288"
+       id="text1422"><tspan
+         sodipodi:role="line"
+         id="tspan1420"
+         x="44.634014"
+         y="51.850288"
+         style="stroke-width:0.264583">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="80.715401"
+       y="52.38483"
+       id="text1426"><tspan
+         sodipodi:role="line"
+         id="tspan1424"
+         x="80.715401"
+         y="52.38483"
+         style="stroke-width:0.264583">3</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="2.939965"
+       y="32.072342"
+       id="text1430"><tspan
+         sodipodi:role="line"
+         id="tspan1428"
+         x="2.939965"
+         y="32.072342"
+         style="stroke-width:0.264583">pos:</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="46.772167"
+       y="31.805075"
+       id="text1486"><tspan
+         sodipodi:role="line"
+         id="tspan1484"
+         x="46.772167"
+         y="31.805075"
+         style="stroke-width:0.264583">1       2        3 </tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 122.67671,63.075608 C 127.94857,65.66535 109.65905,88.681532 85.793517,87.931674 69.293238,88.402958 52.247878,81.69312 44.901281,67.61919"
+       id="path1574"
+       sodipodi:nodetypes="ccc" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.654579"
+       id="path1576"
+       sodipodi:sides="3"
+       sodipodi:cx="40.357697"
+       sodipodi:cy="63.610146"
+       sodipodi:r1="5.8860006"
+       sodipodi:r2="2.9430001"
+       sodipodi:arg1="0.68892422"
+       sodipodi:arg2="1.7361218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 44.901279,67.351918 -5.027922,-0.838901 -5.027922,-0.8389 3.240471,-3.934858 3.240469,-3.934858 1.787452,4.773759 z"
+       inkscape:transform-center-x="0.034446721"
+       inkscape:transform-center-y="-0.77231418"
+       transform="matrix(-0.21872241,0.5890706,-0.55076401,-0.30249408,88.984104,60.493257)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 57.195677,62.273798 c 3.507707,10.665114 15.416752,9.902032 15.501634,9.888973 5.005204,-0.832237 9.505279,-0.996945 11.759859,-8.018085"
+       id="path1578"
+       sodipodi:nodetypes="ccc" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.654579"
+       id="path1583"
+       sodipodi:sides="3"
+       sodipodi:cx="84.724442"
+       sodipodi:cy="62.541069"
+       sodipodi:r1="2.2678571"
+       sodipodi:r2="1.1339285"
+       sodipodi:arg1="0.78539816"
+       sodipodi:arg2="1.8325957"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 86.328059,64.144686 -1.8971,-0.508326 -1.897099,-0.508326 1.388773,-1.388774 1.388773,-1.388773 0.508326,1.8971 z"
+       inkscape:transform-center-x="0.29348324"
+       inkscape:transform-center-y="-0.29348297" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 93.277064,39.288621 c 8.815066,-9.475743 14.760526,-6.325173 20.045216,-0.267269"
+       id="path1597"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.654579"
+       id="path1599"
+       sodipodi:sides="3"
+       sodipodi:cx="114.39136"
+       sodipodi:cy="40.09043"
+       sodipodi:r1="2.2039609"
+       sodipodi:r2="1.1019804"
+       sodipodi:arg1="2.896614"
+       sodipodi:arg2="3.9438115"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 112.2532,40.62497 1.37216,-1.326753 1.37215,-1.326753 0.46293,1.851698 0.46292,1.851697 -1.83508,-0.524944 z"
+       inkscape:transform-center-x="0.30307744"
+       inkscape:transform-center-y="-0.26726965" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="24.054258"
+       y="100.22607"
+       id="text1603"><tspan
+         sodipodi:role="line"
+         id="tspan1601"
+         x="24.054258"
+         y="100.22607"
+         style="font-size:4.93889px;stroke-width:0.264583">fig:correct positions of the array = [2,3,1]</tspan></text>
+  </g>
+</svg>

--- a/1166/cycle_detection.svg
+++ b/1166/cycle_detection.svg
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="544"
+   height="480"
+   viewBox="0 0 143.93333 127"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="cycle_detection.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="77.028125"
+     inkscape:cy="341.6677"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer3"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1431"
+     inkscape:window-height="1030"
+     inkscape:window-x="96"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2"
+     style="display:inline">
+    <rect
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.654579"
+       id="rect1611"
+       width="144.59282"
+       height="134.16931"
+       x="0"
+       y="-4.543582" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.558772"
+       id="rect1402"
+       width="106.46908"
+       height="25.48641"
+       x="32.29171"
+       y="30.420824" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.230261px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 55.04749,30.481444 c 0,25.328596 0.555363,25.133761 0.555363,25.133761"
+       id="path1412" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.229579px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 99.691536,56.700746 C 99.424266,29.132378 99.156996,29.132378 99.156996,29.132378"
+       id="path1414" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="107.70962"
+       y="46.237629"
+       id="text1418"><tspan
+         sodipodi:role="line"
+         id="tspan1416"
+         x="107.70962"
+         y="46.237629"
+         style="stroke-width:0.264583">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="38.219543"
+       y="47.306709"
+       id="text1422"><tspan
+         sodipodi:role="line"
+         id="tspan1420"
+         x="38.219543"
+         y="47.306709"
+         style="stroke-width:0.264583">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="80.715401"
+       y="47.306709"
+       id="text1426"><tspan
+         sodipodi:role="line"
+         id="tspan1424"
+         x="80.715401"
+         y="47.306709"
+         style="stroke-width:0.264583">3</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="0.80180871"
+       y="14.699823"
+       id="text1430"><tspan
+         sodipodi:role="line"
+         id="tspan1428"
+         x="0.80180871"
+         y="14.699823"
+         style="stroke-width:0.264583">pos:</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="41.426777"
+       y="13.898016"
+       id="text1486"><tspan
+         sodipodi:role="line"
+         id="tspan1484"
+         x="41.426777"
+         y="13.898016"
+         style="stroke-width:0.264583">1    2    3    4    5</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.230261px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 76.173998,30.673198 c 0,25.328596 0.555363,25.133761 0.555363,25.133761"
+       id="path1412-2" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.230261px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 122.14435,30.940468 c 0,25.328596 0.55537,25.133761 0.55537,25.133761"
+       id="path1412-3" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="62.541073"
+       y="47.306705"
+       id="text1786"><tspan
+         sodipodi:role="line"
+         id="tspan1784"
+         x="62.541073"
+         y="47.306705"
+         style="stroke-width:0.264583">4</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="126.15121"
+       y="46.504894"
+       id="text1790"><tspan
+         sodipodi:role="line"
+         id="tspan1788"
+         x="126.15121"
+         y="46.504894"
+         style="stroke-width:0.264583">5</tspan></text>
+    <path
+       style="fill:none;stroke:#00c500;stroke-width:0.565;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 39.021351,34.477769 c 6.949616,-17.058253 12.493206,-10.496591 23.786986,0"
+       id="path1792"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#00c500;stroke-width:0.565;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 107.44235,34.745038 c -10.888342,-10.794797 -21.524447,-23.134546 -37.952274,0"
+       id="path1794"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#00c500;stroke-width:0.565;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 112.2532,52.117557 C 68.650173,76.339482 57.58606,62.845845 44.36674,51.850288"
+       id="path1796"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#0000d5;stroke-width:0.865;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 91.138907,50.781209 c 4.655835,3.714509 21.326393,25.783409 38.486813,1.069078"
+       id="path1800"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#0000d5;stroke-width:0.865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1802-7"
+       sodipodi:sides="3"
+       sodipodi:cx="130.88846"
+       sodipodi:cy="51.312618"
+       sodipodi:r1="2.5355415"
+       sodipodi:r2="1.2677706"
+       sodipodi:arg1="-0.32175055"
+       sodipodi:arg2="0.725447"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       inkscape:transform-center-x="0.56696529"
+       inkscape:transform-center-y="2.5967367"
+       d="m 133.29388,50.51081 -1.45687,1.642936 -1.45688,1.642937 -0.69438,-2.08316 -0.69439,-2.08316 2.15126,0.440223 z"
+       transform="rotate(-45,129.97594,51.690595)" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#00e300;stroke-width:0.865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1824"
+       sodipodi:sides="3"
+       sodipodi:cx="47.573975"
+       sodipodi:cy="81.784477"
+       sodipodi:r1="4.9282069"
+       sodipodi:r2="2.4641032"
+       sodipodi:arg1="0.86217005"
+       sodipodi:arg2="1.9093676"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 50.781209,85.526251 -4.025661,-1.417557 -4.025662,-1.417557 3.240471,-2.777546 3.240471,-2.777547 0.785191,4.195103 z"
+       inkscape:transform-center-x="0.47878506"
+       inkscape:transform-center-y="-0.21654458"
+       transform="matrix(0.58500633,0,0,0.47767476,36.047988,-3.9315125)" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#00e300;stroke-width:0.865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1824-3"
+       sodipodi:sides="3"
+       sodipodi:cx="47.573975"
+       sodipodi:cy="81.784477"
+       sodipodi:r1="4.9282069"
+       sodipodi:r2="2.4641032"
+       sodipodi:arg1="0.86217005"
+       sodipodi:arg2="1.9093676"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       inkscape:transform-center-x="0.47878506"
+       inkscape:transform-center-y="-0.21654458"
+       transform="matrix(0.58500633,0,0,0.47767476,79.372287,-4.0667899)"
+       d="m 50.781209,85.526251 -4.025661,-1.417557 -4.025662,-1.417557 3.240471,-2.777546 3.240471,-2.777547 0.785191,4.195103 z" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#00e300;stroke-width:0.865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1824-6"
+       sodipodi:sides="3"
+       sodipodi:cx="47.573975"
+       sodipodi:cy="81.784477"
+       sodipodi:r1="4.9282069"
+       sodipodi:r2="2.4641032"
+       sodipodi:arg1="0.86217005"
+       sodipodi:arg2="1.9093676"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       inkscape:transform-center-x="-0.041350255"
+       inkscape:transform-center-y="-0.17512474"
+       transform="matrix(0.15141078,0.56507272,-0.46139839,0.12363133,73.857959,14.041884)"
+       d="m 50.781209,85.526251 -4.025661,-1.417557 -4.025662,-1.417557 3.240471,-2.777546 3.240471,-2.777547 0.785191,4.195103 z" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#0000d5;stroke-width:0.865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1802-7-6"
+       sodipodi:sides="3"
+       sodipodi:cx="91.880302"
+       sodipodi:cy="37.004059"
+       sodipodi:r1="2.5355415"
+       sodipodi:r2="1.2677706"
+       sodipodi:arg1="-0.32175055"
+       sodipodi:arg2="0.725447"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       inkscape:transform-center-x="0.29936936"
+       inkscape:transform-center-y="0.68716923"
+       d="m 94.285728,36.20225 -1.456876,1.642937 -1.456876,1.642936 -0.694386,-2.08316 -0.694387,-2.08316 2.151263,0.440224 z" />
+    <path
+       style="fill:none;stroke:#0000d5;stroke-width:0.865;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 92.165222,35.33816 c 4.01774,-7.64358 18.668208,-21.532228 38.486808,1.069078"
+       id="path1800-1"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="11.759859"
+       y="87.664398"
+       id="text1897"><tspan
+         sodipodi:role="line"
+         id="tspan1895"
+         x="11.759859"
+         y="87.664398"
+         style="font-size:4.93889px;stroke-width:0.264583">fig : 2 cycles in the giver array = [2,4,3,1,5]</tspan><tspan
+         sodipodi:role="line"
+         x="11.759859"
+         y="93.838013"
+         style="font-size:4.93889px;stroke-width:0.264583"
+         id="tspan1899">       Green cycle has 3 elements (2,4,1) and </tspan><tspan
+         sodipodi:role="line"
+         x="11.759859"
+         y="100.01162"
+         style="font-size:4.93889px;stroke-width:0.264583"
+         id="tspan1901">       Blue cycle has 2 elements (3,5).</tspan><tspan
+         sodipodi:role="line"
+         x="11.759859"
+         y="106.18523"
+         style="font-size:4.93889px;stroke-width:0.264583"
+         id="tspan1903">       </tspan></text>
+  </g>
+</svg>

--- a/1166/cycle_detection.svg
+++ b/1166/cycle_detection.svg
@@ -27,7 +27,7 @@
      inkscape:cx="77.028125"
      inkscape:cy="341.6677"
      inkscape:document-units="mm"
-     inkscape:current-layer="layer3"
+     inkscape:current-layer="layer1"
      inkscape:document-rotation="0"
      showgrid="false"
      units="px"
@@ -289,7 +289,7 @@
          id="tspan1895"
          x="11.759859"
          y="87.664398"
-         style="font-size:4.93889px;stroke-width:0.264583">fig : 2 cycles in the giver array = [2,4,3,1,5]</tspan><tspan
+         style="font-size:4.93889px;stroke-width:0.264583">fig : 2 cycles in the given array = [2,4,3,1,5]</tspan><tspan
          sodipodi:role="line"
          x="11.759859"
          y="93.838013"

--- a/1166/en.md
+++ b/1166/en.md
@@ -1,0 +1,78 @@
+# LOJ-1166: Old Sort
+
+----
+
+**What the problem wants:** The problem gives you an array of integer numbers of size `n` and asks you how many swaps you need to turn the array into sorted array (in ascending order). The array will be a permutation of number `1` to `n`. This means elements of array will consist of all numbers from `1` to `n`.
+
+**General approach to the problem:** We can first try to find a pattern into the number of swaps we need for sorting the array.Since numbers range from `1 to n`, a correctly placed number will be at it's representing position because all elements will be from 1 to n. For example in a sorted array 1 will be at position:1 and 3 will be at position:3.
+
+![correct_position](correct_position.svg)
+
+Let's analyze how many number we can correctly place in one swap. We can at least correctly place any number in its proper position with one swap if we swap it with the element there at its correct position. Two things can happen to the number we will be swapping out . One, it will go to an incorrect position . Two, it will be at its correct position meaning both elements will be properly positioned with one swap.
+
+![swapping_distribution](swapping_distribution.svg)
+
+Now that we have an understanding of the swap operation. Let's visualize the array of numbers as a graph where the value at each index shows where they will go. If we group the number that will need to interchange their position or swap we can find that they form cycles of numbers.
+
+![cycle_detection](cycle_detection.svg)
+
+Bringing each cycle in correct order will require `number of elements in the cycle - 1` swaps. If we sum all required swaps for correctly ordering each cycle we can easily find our answer.
+
+So , If there are `k` cycles in the array and number of element in each cycle is `x` then,
+
+**answer =  $\sum_{i=1}^{i=k} (x_i-1)$**
+
+**Resources:**  
+
+* [Geek for geeks blog on finding minimum numbers of swaps](https://www.geeksforgeeks.org/minimum-number-swaps-required-sort-array/)
+* [A more generalized solution to the problem by TutorialsPoint, for random numbers instead of 1 to n.](https://www.tutorialspoint.com/minimum-number-of-swaps-required-to-sort-an-array-in-cplusplus)
+* [Video tutorial on YouTube by DSAlgo (Code in Java)](https://www.youtube.com/watch?v=J9ikRMK8Yhs)
+
+----
+
+## Solution Code in C++
+
+```cpp
+#include <bits/stdc++.h>
+using namespace std;
+
+int main()
+{
+    int cas;
+    cin>>cas;
+    for(int kase=1;kase<=cas;kase++)
+    {
+        int n,ans=0;
+        cin>>n;      
+        
+        int a[n+1]= {};    //for given arary
+        bool vis[n+1]= {}; //for tracking visited numbers (when checking for cycles)
+        
+        for(int i=1; i<=n; i++)
+        {
+            cin>>a[i];
+        }
+        
+        for(int i=1; i<=n; i++)
+        {
+            int k=i,cycle=0; // "cycle" is for detecting the number of cycle 
+            
+            if(!vis[k]) // if c[k] is unvisited it means we haven't covered the cycle 'k' belongs in yet.
+            {   
+                //For finding the number of elements in each cycle
+                while(!vis[k])
+                {
+                    cycle ++;
+                    vis[k] = true;
+                    k = a[k]; 
+                }
+                
+                ans+=cycle-1; //summing answer according to formula.
+            }
+        }
+        cout<<"Case "<<kase<<": "<<ans<<'\n';
+    }
+    return 0;
+}
+
+```

--- a/1166/en.md
+++ b/1166/en.md
@@ -45,7 +45,7 @@ int main()
         int n,ans=0;
         cin>>n;      
         
-        int a[n+1]= {};    //for given arary
+        int a[n+1]= {};    //for given array
         bool vis[n+1]= {}; //for tracking visited numbers (when checking for cycles)
         
         for(int i=1; i<=n; i++)

--- a/1166/swapping_distribution.svg
+++ b/1166/swapping_distribution.svg
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="544"
+   height="480"
+   viewBox="0 0 143.93333 127"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="swapping_distribution.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="251.69043"
+     inkscape:cy="341.6677"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer3"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1431"
+     inkscape:window-height="1030"
+     inkscape:window-x="96"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2"
+     style="display:inline">
+    <rect
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.654579"
+       id="rect1611"
+       width="144.59282"
+       height="134.16931"
+       x="0"
+       y="-4.543582" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.558772"
+       id="rect1402"
+       width="106.46908"
+       height="25.48641"
+       x="32.29171"
+       y="16.522808" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.230261px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 63.600115,17.117968 c 0,25.328596 0.555363,25.133761 0.555363,25.133761"
+       id="path1412" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.229579px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 102.89877,42.802731 C 102.6315,15.234363 102.36423,15.234363 102.36423,15.234363"
+       id="path1414" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="116.79678"
+       y="32.874153"
+       id="text1418"><tspan
+         sodipodi:role="line"
+         id="tspan1416"
+         x="116.79678"
+         y="32.874153"
+         style="stroke-width:0.264583">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="44.634014"
+       y="32.874153"
+       id="text1422"><tspan
+         sodipodi:role="line"
+         id="tspan1420"
+         x="44.634014"
+         y="32.874153"
+         style="stroke-width:0.264583">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="80.715401"
+       y="33.408695"
+       id="text1426"><tspan
+         sodipodi:role="line"
+         id="tspan1424"
+         x="80.715401"
+         y="33.408695"
+         style="stroke-width:0.264583">3</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="2.6726954"
+       y="11.492589"
+       id="text1430"><tspan
+         sodipodi:role="line"
+         id="tspan1428"
+         x="2.6726954"
+         y="11.492589"
+         style="stroke-width:0.264583">pos:</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="47.039436"
+       y="13.898016"
+       id="text1486"><tspan
+         sodipodi:role="line"
+         id="tspan1484"
+         x="47.039436"
+         y="13.898016"
+         style="stroke-width:0.264583">1       2        3 </tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 53.721174,25.657874 C 62.53624,16.182132 68.4817,19.332702 73.76639,25.390605"
+       id="path1597"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.654579"
+       id="path1599"
+       sodipodi:sides="3"
+       sodipodi:cx="74.835464"
+       sodipodi:cy="26.459684"
+       sodipodi:r1="2.2039609"
+       sodipodi:r2="1.1019804"
+       sodipodi:arg1="2.896614"
+       sodipodi:arg2="3.9438115"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 72.697308,26.994223 1.372155,-1.326753 1.372155,-1.326753 0.462925,1.851698 0.462924,1.851697 -1.835079,-0.524944 z"
+       inkscape:transform-center-x="0.30307744"
+       inkscape:transform-center-y="-0.26726965" />
+    <rect
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.558772"
+       id="rect1402-0"
+       width="106.46908"
+       height="25.48641"
+       x="32.024441"
+       y="50.84119" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.230261px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 64.936462,51.436346 c 0,25.328599 0.555363,25.133759 0.555363,25.133759"
+       id="path1412-1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.229579px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 104.23512,77.121105 C 103.96785,49.552741 103.70058,49.552741 103.70058,49.552741"
+       id="path1414-7" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="117.06405"
+       y="65.588921"
+       id="text1418-8"><tspan
+         sodipodi:role="line"
+         id="tspan1416-5"
+         x="117.06405"
+         y="65.588921"
+         style="stroke-width:0.264583">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="81.249939"
+       y="66.123451"
+       id="text1422-5"><tspan
+         sodipodi:role="line"
+         id="tspan1420-5"
+         x="81.249939"
+         y="66.123451"
+         style="stroke-width:0.264583">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="47.03944"
+       y="65.588921"
+       id="text1426-4"><tspan
+         sodipodi:role="line"
+         id="tspan1424-1"
+         x="47.03944"
+         y="65.588921"
+         style="stroke-width:0.264583">3</tspan></text>
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.654579"
+       id="path1599-4"
+       sodipodi:sides="3"
+       sodipodi:cx="53.846996"
+       sodipodi:cy="25.202717"
+       sodipodi:r1="2.2039609"
+       sodipodi:r2="1.1019804"
+       sodipodi:arg1="2.896614"
+       sodipodi:arg2="3.9438115"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       inkscape:transform-center-x="0.30307744"
+       inkscape:transform-center-y="-0.26726965"
+       d="m 51.70884,25.737256 1.372155,-1.326753 1.372155,-1.326753 0.462924,1.851697 0.462925,1.851698 L 53.54392,26.2622 Z" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 53.988444,70.024616 c 27.298507,27.261817 51.091546,15.121759 65.748306,0.267268"
+       id="path1718"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.654579"
+       id="path1599-4-4"
+       sodipodi:sides="3"
+       sodipodi:cx="119.86257"
+       sodipodi:cy="69.302185"
+       sodipodi:r1="2.2039609"
+       sodipodi:r2="1.1019804"
+       sodipodi:arg1="2.896614"
+       sodipodi:arg2="3.9438115"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       inkscape:transform-center-x="0.30307744"
+       inkscape:transform-center-y="-0.26726965"
+       d="m 117.72442,69.836724 1.37215,-1.326753 1.37216,-1.326753 0.46292,1.851697 0.46292,1.851698 -1.83508,-0.524944 z" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.963934;fill:#ffffff;stroke:#000000;stroke-width:0.654579"
+       id="path1599-4-0"
+       sodipodi:sides="3"
+       sodipodi:cx="36.474476"
+       sodipodi:cy="90.416481"
+       sodipodi:r1="2.2039609"
+       sodipodi:r2="1.1019804"
+       sodipodi:arg1="2.896614"
+       sodipodi:arg2="3.9438115"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       inkscape:transform-center-x="-0.53485975"
+       inkscape:transform-center-y="6.3959334"
+       d="m 34.33632,90.95102 1.372155,-1.326753 1.372155,-1.326753 0.462924,1.851697 0.462924,1.851698 -1.835079,-0.524944 z"
+       transform="rotate(-45,18.761015,59.266825)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="5.0781212"
+       y="96.217033"
+       id="text1751"><tspan
+         sodipodi:role="line"
+         id="tspan1749"
+         x="5.0781212"
+         y="96.217033"
+         style="font-size:4.93889px;stroke-width:0.264583">fig: first swap puts only one number in correct position</tspan><tspan
+         sodipodi:role="line"
+         x="5.0781212"
+         y="102.39065"
+         style="font-size:4.93889px;stroke-width:0.264583"
+         id="tspan1753">      second swap puts both number in correct postion</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
The English editorial has been added. File contains images in the svg format. Images are used inside the markdown for helping the readers visualize the process of solution. 
This pull request solves the issue #367 