### PR TITLE
GH Actions: Label/close issue if inactive for 30/+10 days

### DIFF
--- a/.github/workflows/inactive_issue.yml
+++ b/.github/workflows/inactive_issue.yml
@@ -1,0 +1,28 @@
+name: Close inactive issues
+
+on:
+  # Run this workflow weekly on Friday at 00:00 UTC
+  # [cron](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
+  schedule:
+    - cron: "0 0 * * 5"
+
+jobs:
+  close-inactive-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      # https://github.com/marketplace/actions/close-stale-issues
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 10
+          stale-issue-label: "inactive"
+          stale-issue-message: "This issue was labeled `inactive` because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because there has been no activity for 10 days since being labeled as `inactive`."
+          # do not mark PRs as stale/inactive
+          days-before-pr-stale: -1
+          # do not close PRs
+          days-before-pr-close: -1
+


### PR DESCRIPTION
Create a Github Workflow that runs weekly on Friday at 00:00 UTC
and labels an issue as `inactive` if the issue had no activity for more
than 30 days. If the issue doesn't receive any further response within
the next 10 days, the issue will be closed on the next workflow run.